### PR TITLE
Fix installer ipk hash (v0.4.0 hash pinned against v0.4.1 URL)

### DIFF
--- a/installer/tv-install.sh
+++ b/installer/tv-install.sh
@@ -11,7 +11,7 @@
 
 APP_ID="tld.my.customhome"
 IPK_URL="https://github.com/zzeppieri/webos-custom-home/releases/download/v0.4.1/tld.my.customhome_0.4.1_all.ipk"
-IPK_HASH="703dffaaea0f899d81109a525c75dff024fa45df8425c81beba35361486bfaad"  # sha256 of the ipk
+IPK_HASH="e1f7c6205b18d5b900052bba265b0fcec274df236ab61fe14fbd3663adf16a39"  # sha256 of the ipk
 SVCDIR="/media/developer/apps/usr/palm/services/${APP_ID}.service"
 INITD="/var/lib/webosbrew/init.d/50-customhome"
 HB="luna://org.webosbrew.hbchannel.service/install"


### PR DESCRIPTION
The one-click installer currently fails for everyone on v0.4.1.

`installer/tv-install.sh` points `IPK_URL` at the **v0.4.1** ipk but still pins **v0.4.0**'s sha256:

```sh
IPK_URL="…/releases/download/v0.4.1/tld.my.customhome_0.4.1_all.ipk"
IPK_HASH="703dffaaea0f899d81109a525c75dff024fa45df8425c81beba35361486bfaad"  # <- v0.4.0
```

`aaedb76` ("Point installer + docs at the v0.4.1 release") bumped the URL and missed the hash. Since `org.webosbrew.hbchannel.service/install` verifies `ipkHash`, the download is rejected and the status loop times out with "install did not complete".

Hashes from the GitHub release API (`/repos/zzeppieri/webos-custom-home/releases`):

| Asset | Published digest |
|---|---|
| `tld.my.customhome_0.4.0_all.ipk` | `703dffaa…86bfaad` ← currently pinned |
| `tld.my.customhome_0.4.1_all.ipk` | `e1f7c620…adf16a39` ← correct |

Confirmed by downloading the v0.4.1 asset and hashing it locally, and again after copying it onto the TV — all three agree on `e1f7c620…`.

Verified end to end on an LG OLED65C4PUA (webOS 10.3.1, Rockhopper 10.3.1-3006, Homebrew Channel 0.7.3): with the corrected hash the hbchannel install succeeds and the app, its service, and the launch point all register. With the pinned hash it does not.

**Note:** this only fixes the copy in the repo. The `tv-install.sh` asset attached to the **v0.4.1 release** carries the same bad hash (digest `7371e016…`), and that's the file the README's one-liner tells people to `curl`. That asset needs re-uploading separately — a PR can't reach it.

Thanks for the project, it's genuinely nice.